### PR TITLE
Properly unwraps results for get! and find! function variants; bumps to 0.1.1

### DIFF
--- a/lib/iso_lang.ex
+++ b/lib/iso_lang.ex
@@ -72,7 +72,7 @@ defmodule IsoLang do
   """
   def get!(query, opts \\ []) do
     case get(query, opts) do
-      {:ok, lang} -> {:ok, lang}
+      {:ok, lang} -> lang
       {:error, error} -> raise error
     end
   end
@@ -117,7 +117,7 @@ defmodule IsoLang do
   """
   def find!(query, opts \\ []) do
     case find(query, opts) do
-      {:ok, lang} -> {:ok, lang}
+      {:ok, lang} -> lang
       {:error, error} -> raise error
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule IsoLang.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
 
   def project do
     [
@@ -11,7 +11,7 @@ defmodule IsoLang.MixProject do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
-      description: "Converts from between ISO-639 standard to human readable names to native names",
+      description: "Formalizes interface for ISO-639 language codes and assists with conversion",
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [

--- a/test/iso_lang_test.exs
+++ b/test/iso_lang_test.exs
@@ -27,6 +27,17 @@ defmodule IsoLangTest do
     end
   end
 
+  describe "get!/2" do
+    test "gets language when exists" do
+      assert %IsoLang{alpha2: "de", alpha3b: "ger", alpha3t: "deu", name: "German"} =
+               IsoLang.get!("de")
+    end
+
+    test "raises when no language is found" do
+      assert_raise RuntimeError, fn -> IsoLang.get!("invalid") end
+    end
+  end
+
   describe "find/2" do
     test "Match partial names" do
       assert {:ok,
@@ -61,6 +72,33 @@ defmodule IsoLangTest do
 
     test "Empty list when no match is found in standard" do
       assert {:ok, []} = IsoLang.find("eng", by: :alpha2)
+    end
+  end
+
+  describe "find!/2" do
+    test "match on partial names" do
+      assert [
+               %IsoLang{
+                 alpha2: "",
+                 alpha3b: "ang",
+                 alpha3t: "",
+                 name: "English, Old (ca.450-1100)"
+               },
+               %IsoLang{alpha2: "bn", alpha3b: "ben", alpha3t: "", name: "Bengali"},
+               %IsoLang{
+                 alpha2: "",
+                 alpha3b: "cpe",
+                 alpha3t: "",
+                 name: "Creoles and pidgins, English based"
+               },
+               %IsoLang{alpha2: "en", alpha3b: "eng", alpha3t: "", name: "English"},
+               %IsoLang{
+                 alpha2: "",
+                 alpha3b: "enm",
+                 alpha3t: "",
+                 name: "English, Middle (1100-1500)"
+               }
+             ] = IsoLang.find!("eng")
     end
   end
 end


### PR DESCRIPTION
The `get!/2` and `find!/2` functions are refactored to return unwrapped output. Tests added.