### PR TITLE
Moves Gettext to hidden module, makes Data module private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.0
+
+- Moves `use Gettext` inside "private" module so we don't pollute the `IsoLang` namespace with all the generated functions.
+- Sets `IsoLang.Data` to `@moduledoc false` to better communicate that it is an implementation detail without stand-alone functionality
+
 ## v0.3.1
 
 - Adds `CHANGELOG`

--- a/lib/iso_lang.ex
+++ b/lib/iso_lang.ex
@@ -11,9 +11,6 @@ defmodule IsoLang do
   - https://tools.ietf.org/search/bcp47
   - https://datahub.io/core/language-codes#resource-language-codes-full
   """
-
-  use Gettext, otp_app: :iso_lang
-
   @type t :: %__MODULE__{
           alpha2: String.t(),
           alpha3b: String.t(),
@@ -24,10 +21,17 @@ defmodule IsoLang do
 
   defstruct alpha2: nil, alpha3b: nil, alpha3t: nil, name: nil, native_name: nil
 
+  defmodule Backend do
+    @moduledoc false
+    # We rely on a dedicated "private" module as the Gettext backend so we don't
+    # pollute the IsoLang docs with all the generated Gettext functions
+    use Gettext, otp_app: :iso_lang
+  end
+
   @doc """
   Returns a list of all available ISO language codes.
   """
-  defdelegate all(opts \\ []), to: IsoLang.Data
+  def all(opts \\ []), do: IsoLang.Data.all(opts)
 
   @doc """
   Gets a single language struct identified by a field.

--- a/lib/iso_lang/data.ex
+++ b/lib/iso_lang/data.ex
@@ -1,11 +1,10 @@
 defmodule IsoLang.Data do
-  @moduledoc """
-  Builds list of language codes at compile-time.
-
-  Data sourced from https://datahub.io/core/language-codes#resource-language-codes-full
-  Native language names adapted from https://github.com/meikidd/iso-639-1/blob/master/src/data.js
-  """
-
+  @moduledoc false
+  # Builds list of language codes at compile-time.
+  #
+  # Data sourced from https://datahub.io/core/language-codes#resource-language-codes-full
+  # Native language names adapted from https://github.com/meikidd/iso-639-1/blob/master/src/data.js
+  #
   # External resource used by this module
   # https://hexdocs.pm/elixir/Module.html#module-external_resource
   @external_resource Application.app_dir(:iso_lang, ["priv", "language-codes-full.csv"])
@@ -223,7 +222,7 @@ defmodule IsoLang.Data do
         alpha2: alpha2,
         alpha3b: alpha3b,
         alpha3t: alpha3t,
-        name: Gettext.gettext(IsoLang, f.(tail)),
+        name: Gettext.gettext(IsoLang.Backend, f.(tail)),
         native_name: Map.get(native_names, alpha2)
       }
     end)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule IsoLang.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/luoken/iso_lang"
-  @version "0.3.1"
+  @version "0.4.0"
 
   def project do
     [
@@ -12,7 +12,8 @@ defmodule IsoLang.MixProject do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
-      description: "Formalizes interface for ISO-639 language codes and assists with conversion",
+      description:
+        "Formalizes interface for ISO-639 language codes and assists with language-code conversion",
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [
@@ -35,7 +36,8 @@ defmodule IsoLang.MixProject do
         main: "readme",
         source_ref: "v#{@version}",
         source_url: @source_url,
-        extras: extras()
+        extras: extras(),
+        skip_undefined_reference_warnings_on: ["CHANGELOG.md"]
       ]
     ]
   end


### PR DESCRIPTION
These changes cleanup the function API for the package -- it pegs a couple modules as private so users can focus on the stuff that this package actually provides.